### PR TITLE
Print progress on one line

### DIFF
--- a/homura.py
+++ b/homura.py
@@ -273,7 +273,7 @@ class Homura(object):
                 if interval < 0.5:
                     return
                 self._last_time = current_time
-            p = (self.progress_template + '\n') % params
+            p = ("\r" + self.progress_template) % params
         STREAM.write(p)
         STREAM.flush()
 


### PR DESCRIPTION
I'm running on OS X, and the progress function would print a new line every time it updated. I made this change so that the progress function would update the same line every time, keeping the terminal output cleaner - let me know what you think!